### PR TITLE
ignore page move when parentless in hookSaveReady

### DIFF
--- a/ProcessSetupPageName.module
+++ b/ProcessSetupPageName.module
@@ -401,6 +401,7 @@ class ProcessSetupPageName extends Process implements Module, ConfigurableModule
 	 */
     public function hookSaveReady($event) {
     	$page = $event->arguments[0];
+		if ($page->parent() instanceof NullPage) return; // intermittent page move
     	$format = $page->parent()->template->childNameFormat;
     	if (!strlen($format)) return;
 		$SetupPageName = $this->wire('modules')->get('ProcessSetupPageName');


### PR DESCRIPTION
Avoid errors when moving page in tree:
```
1× 	PHP Warning: Attempt to read property "childNameFormat" on null in [.../modules/ProcessSetupPageName/ProcessSetupPageName.module:405]

1× 	PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in [.../modules/ProcessSetupPageName/ProcessSetupPageName.module:406]
```